### PR TITLE
Add .NET Aspire API example

### DIFF
--- a/BasicApi.AppHost/BasicApi.AppHost.csproj
+++ b/BasicApi.AppHost/BasicApi.AppHost.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BasicApi\BasicApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/BasicApi.AppHost/Program.cs
+++ b/BasicApi.AppHost/Program.cs
@@ -1,0 +1,6 @@
+using Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+builder.AddProject<Projects.BasicApi>("basicapi");
+
+builder.Build().Run();

--- a/BasicApi.AppHost/Projects.cs
+++ b/BasicApi.AppHost/Projects.cs
@@ -1,0 +1,3 @@
+namespace Projects;
+
+public class BasicApi { }

--- a/BasicApi.Tests/BasicApi.Tests.csproj
+++ b/BasicApi.Tests/BasicApi.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BasicApi\BasicApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/BasicApi.Tests/UnitTests/ApiTests.cs
+++ b/BasicApi.Tests/UnitTests/ApiTests.cs
@@ -1,0 +1,23 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Xunit;
+
+public class ApiTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public ApiTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetTestReturnsHolaMundo()
+    {
+        var response = await _client.GetAsync("/api/test");
+        response.EnsureSuccessStatusCode();
+        var text = await response.Content.ReadAsStringAsync();
+        Assert.Equal("hola mundo", text);
+    }
+}

--- a/BasicApi/BasicApi.csproj
+++ b/BasicApi/BasicApi.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/BasicApi/Program.cs
+++ b/BasicApi/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/api/test", () => "hola mundo");
+
+app.Run();
+
+public partial class Program { }

--- a/CodexTest.sln
+++ b/CodexTest.sln
@@ -1,0 +1,30 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicApi", "BasicApi\BasicApi.csproj", "{b7ef6bbc-8681-ce1b-db4e-d682592f7a7a}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicApi.Tests", "BasicApi.Tests\BasicApi.Tests.csproj", "{4473dfd0-b935-aa9d-425e-c1423435274c}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicApi.AppHost", "BasicApi.AppHost\BasicApi.AppHost.csproj", "{308a8d6d-626c-f90a-a17b-cca7633ba832}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {b7ef6bbc-8681-ce1b-db4e-d682592f7a7a}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {b7ef6bbc-8681-ce1b-db4e-d682592f7a7a}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {b7ef6bbc-8681-ce1b-db4e-d682592f7a7a}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {b7ef6bbc-8681-ce1b-db4e-d682592f7a7a}.Release|Any CPU.Build.0 = Release|Any CPU
+        {4473dfd0-b935-aa9d-425e-c1423435274c}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {4473dfd0-b935-aa9d-425e-c1423435274c}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {4473dfd0-b935-aa9d-425e-c1423435274c}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {4473dfd0-b935-aa9d-425e-c1423435274c}.Release|Any CPU.Build.0 = Release|Any CPU
+        {308a8d6d-626c-f90a-a17b-cca7633ba832}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {308a8d6d-626c-f90a-a17b-cca7633ba832}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {308a8d6d-626c-f90a-a17b-cca7633ba832}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {308a8d6d-626c-f90a-a17b-cca7633ba832}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # CodexTest
-CodexTest
+
+Este repositorio contiene un ejemplo minimal de una solucion .NET 8 que utiliza **.NET Aspire**. La solucion incluye un proyecto de API, un proyecto de pruebas y un proyecto de AppHost para orquestar la aplicacion.
+
+## Estructura
+- `BasicApi` – API minimal que expone el endpoint `/api/test` devolviendo "hola mundo".
+- `BasicApi.Tests` – proyecto de pruebas basado en xUnit.
+- `BasicApi.AppHost` – host que usa `Aspire.Hosting` para registrar el API.
+
+## Uso
+
+No se incluye el runtime de .NET en este contenedor, pero en un entorno local con .NET 8 instalado se puede ejecutar:
+
+```bash
+# Restaurar paquetes
+ dotnet restore CodexTest.sln
+
+# Ejecutar la API
+ dotnet run --project BasicApi
+
+# Ejecutar las pruebas
+ dotnet test BasicApi.Tests
+```


### PR DESCRIPTION
## Summary
- add BasicApi project with an endpoint that returns `"hola mundo"`
- add xUnit tests verifying the endpoint
- add an Aspire host project
- document how to restore, run and test

## Testing
- `dotnet test BasicApi.Tests/BasicApi.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f667bd988330a63742632fcb04e7